### PR TITLE
Resolve CD issue on PR

### DIFF
--- a/AzureDevOps/agentbuild.yaml
+++ b/AzureDevOps/agentbuild.yaml
@@ -41,6 +41,7 @@ jobs:
   - name: RepoName
     value: h2floh/geobotagent
   steps:
+  
   - task: Docker@0
     displayName: 'Build an image'
     inputs:
@@ -56,3 +57,4 @@ jobs:
       dockerRegistryConnection: 'DockerHub h2floh'
       action: 'Push an image'
       includeLatestTag: true
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))

--- a/AzureDevOps/keyvaultcertbotbuild.yaml
+++ b/AzureDevOps/keyvaultcertbotbuild.yaml
@@ -43,6 +43,7 @@ jobs:
   - name: ImageTag
     value: keyvault
   steps:
+  
   - task: Docker@0
     displayName: 'Build an image'
     inputs:
@@ -58,3 +59,4 @@ jobs:
       dockerRegistryConnection: 'DockerHub h2floh'
       action: 'Push an image'
       includeLatestTag: false
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))


### PR DESCRIPTION
If a PR is requested on the agent or Let's Encrypt KeyVault docker image, the images are directly pushed to the Docker Hub repo and therefore can break (in good case) the execution or (in bad case) act as a side channel attack to reveal secrets and access to Azure Accounts.