### PR TITLE
Update WebChat code to enable speech functionality and change speech controller 

### DIFF
--- a/GeoBot/GeoBot/Controllers/SpeechController.cs
+++ b/GeoBot/GeoBot/Controllers/SpeechController.cs
@@ -32,14 +32,9 @@ namespace GeoBot.Controllers
 
         [Route("speech/region")]
         [HttpGet]
-        public async Task<Token> GetRegionAsync()
-        {
-            Token token = new Token
-            {
-                token = await speech.GetSpeechToken()
-            };
-
-            return token;
+        public string GetRegionAsync()
+        {            
+            return speech.GetSpeechRegion();
         }
     }
 }

--- a/GeoBot/GeoBot/Controllers/SpeechController.cs
+++ b/GeoBot/GeoBot/Controllers/SpeechController.cs
@@ -24,17 +24,11 @@ namespace GeoBot.Controllers
         {
             Token token = new Token
             {
-                token = await speech.GetSpeechToken()
+                token = await speech.GetSpeechToken(),
+                region = speech.GetSpeechRegion()
             };
 
             return token;
-        }
-
-        [Route("speech/region")]
-        [HttpGet]
-        public string GetRegionAsync()
-        {            
-            return speech.GetSpeechRegion();
         }
     }
 }

--- a/GeoBot/GeoBot/Helpers/Token.cs
+++ b/GeoBot/GeoBot/Helpers/Token.cs
@@ -8,6 +8,7 @@ namespace GeoBot.Helpers
     public class Token
     {
         public string token { get; set; }
+        public string region { get; set; }
     }
 
 }

--- a/WebChat/index.html
+++ b/WebChat/index.html
@@ -6,7 +6,7 @@
     <script>
         var params = window.location.search.slice(1).split("&");
         var botname = "";
-        var key = "";
+        var endpoint = "";
 
         for (var p = 0; p < params.length; p++) {
             var nv = params[p].split("=");
@@ -16,23 +16,72 @@
             if (name == "bot") {
                 botname = value;
             }
-            if (name == "key") {
-                key = value;
+            if (name == "endpoint") {
+                endpoint = value;
             }
         }
 
-        window.WebChat.renderWebChat({
-                directLine: window.WebChat.createDirectLine({
-                    token: key
-                }),
-                userID: 'geouser',
-                username: 'Geo User',
-                locale: 'en-US',
-                botAvatarInitials: 'GB',
-                userAvatarInitials: 'GU'
-            },
-            document.getElementById('webchat')
-        );
+        function createFetchSpeechServicesCredentials(){
+            let expireAfter = 0;
+            let lastPromise;
+
+            return () => {
+                if (Date.now() > expireAfter) {
+                    const speechServiceUri = endpoint + "/speech/token";
+                    const speechServicesTokenResPromise = fetch(speechServiceUri, { method: 'GET' });
+
+                    expireAfter = Date.now() + 300000;
+                    lastPromise = speechServicesTokenResPromise.then(
+                        res => res.json(),
+                        err => {
+                            lastPromise = null;
+                            return Promise.reject(err);
+                        }
+                    );
+                }
+                return lastPromise;
+            }
+        }
+
+        async function getDirectlineToken(){
+            let tokenGenerateServiceUri = endpoint + "/directline/token";
+            const directlineToken = await fetch(tokenGenerateServiceUri, { method: 'GET' })
+                .then((res) => res.json())
+                .then(function(result){
+                    return result.token;
+                })
+                .catch(err => console.log(err));
+            return directlineToken;
+        }
+
+        const fetchSpeechServices = createFetchSpeechServicesCredentials();
+
+        (async function() {
+
+            let speechToken = (await fetchSpeechServices()).token;
+            let speechRegion = (await fetchSpeechServices()).region;
+            let directlineToken = await getDirectlineToken();
+
+            const webSpeechPonyfillFactory = await window.WebChat.createCognitiveServicesSpeechServicesPonyfillFactory({
+                authorizationToken: speechToken,
+                region: speechRegion
+            });
+
+            window.WebChat.renderWebChat({
+                    directLine: window.WebChat.createDirectLine({
+                        token: directlineToken
+                    }),
+                    userID: 'geouser',
+                    username: 'Geo User',
+                    locale: 'en-US',
+                    botAvatarInitials: 'GB',
+                    userAvatarInitials: 'GU',
+                    webSpeechPonyfillFactory
+                },
+                document.getElementById('webchat')
+            );
+        })().catch(err => console.error(err));
+        
     </script>
 </body>
 


### PR DESCRIPTION
1. Update WebChat
- Enable speech functionality
- Get speech token, speech region, directline token from controller 
- don't need to pass directline key, because this webchat will get token from controller
- need to pass botname and endpoint url as a parameter
(Example - bot=mybot200108&endpoint=http://localhost:3978) 

2. Update Speech Controller
Previously, speech controller have seperate endpoint to get speech token and speech region
Now, it will give the result as a one json result 